### PR TITLE
Add support for custom rules and fix issues

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -52,7 +52,9 @@ project(group: "org.savantbuild.plugin", name: "linter", version: "2.0.3", licen
       dependency(id: "net.sourceforge.pmd:pmd-java:${pmdVersion}")
       dependency(id: "org.savantbuild:savant-io:${savantVersion}")
     }
-
+    group(name: "runtime") {
+      dependency(id: "org.slf4j:slf4j-simple:1.7.25")
+    }
     group(name: "test-compile", export: false) {
       dependency(id: "org.savantbuild:savant-version:${savantVersion}")
       dependency(id: "org.testng:testng:6.8.7")

--- a/build.savant
+++ b/build.savant
@@ -17,7 +17,7 @@
 pmdVersion = "7.5.0"
 savantVersion = "2.0.0"
 
-project(group: "org.savantbuild.plugin", name: "linter", version: "2.0.2", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild.plugin", name: "linter", version: "2.0.3", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       // Dependency resolution order:
@@ -79,11 +79,11 @@ groovyTestNG.settings.groovyVersion = "4.0"
 groovyTestNG.settings.javaVersion = "17"
 idea.settings.imlFile = "linter-plugin.iml"
 idea.settings.moduleMap = [
-    "org.savantbuild:savant-core:${savantVersion}"                  : "savant-core",
-    "org.savantbuild:savant-dependency-management:${savantVersion}" : "savant-dependency-management",
-    "org.savantbuild:savant-io:${savantVersion}"                    : "savant-io",
-    "org.savantbuild:savant-utils:${savantVersion}"                 : "savant-utils",
-    "org.savantbuild:savant-version:${savantVersion}"               : "savant-version"
+    "org.savantbuild:savant-core:${savantVersion}"                 : "savant-core",
+    "org.savantbuild:savant-dependency-management:${savantVersion}": "savant-dependency-management",
+    "org.savantbuild:savant-io:${savantVersion}"                   : "savant-io",
+    "org.savantbuild:savant-utils:${savantVersion}"                : "savant-utils",
+    "org.savantbuild:savant-version:${savantVersion}"              : "savant-version"
 ]
 
 target(name: "clean", description: "Cleans the project") {

--- a/src/main/groovy/org/savantbuild/plugin/linter/LinterPlugin.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/linter/LinterPlugin.groovy
@@ -57,6 +57,8 @@ class LinterPlugin extends BaseGroovyPlugin {
     boolean reportSuppressedViolations = attributes.getOrDefault("reportSuppressedViolations", false)
     String languageVersion = attributes.getOrDefault("languageVersion", "17")
     String inputPath = attributes.getOrDefault("inputPath", "src/main/java")
+    String sourceClassesPath = attributes.getOrDefault("sourceClassesPath", "build/classes/main")
+    String testClassesPath = attributes.getOrDefault("testClassesPath", "build/classes/test")
     String minimumPriority = attributes.getOrDefault("minimumPriority", "MEDIUM")
     String[] ruleSets = attributes.getOrDefault("ruleSets", [])
     boolean failOnViolations = attributes.getOrDefault("failOnViolations", true)
@@ -91,6 +93,13 @@ class LinterPlugin extends BaseGroovyPlugin {
     PMDConfiguration config = new PMDConfiguration()
     output.infoln("Using PMD version [%s]", PMDVersion.fullVersionName)
     config.addInputPath(project.directory.resolve(inputPath))
+    def auxClassPath = [
+        sourceClassesPath,
+        testClassesPath
+    ].collect { f -> project.directory.resolve(f).toAbsolutePath().toString() }
+        .join(File.pathSeparator)
+    output.infoln("Adding aux classpath [%s]", auxClassPath)
+    config.prependAuxClasspath(auxClassPath)
 
     config.setDefaultLanguageVersion(LanguageRegistry.PMD.getLanguageById("java").getVersion(languageVersion))
     config.setMinimumPriority(RulePriority.valueOf(minimumPriority))

--- a/src/main/groovy/org/savantbuild/plugin/linter/LinterPlugin.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/linter/LinterPlugin.groovy
@@ -66,7 +66,7 @@ class LinterPlugin extends BaseGroovyPlugin {
           new DependencyService.TraversalRules.GroupTraversalRule(false, false))
       def graph = project.dependencyService.resolve(project.artifactGraph, project.workflow, rules)
       customRuleClassPath = graph.toClasspath().toString()
-      output.infoln("Including the following custom rules in the PMD classpath",
+      output.infoln("Including the following custom rules in the PMD classpath: [%s]",
           customRuleClassPath)
     }
 

--- a/src/main/groovy/org/savantbuild/plugin/linter/LinterPlugin.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/linter/LinterPlugin.groovy
@@ -59,6 +59,7 @@ class LinterPlugin extends BaseGroovyPlugin {
     String inputPath = attributes.getOrDefault("inputPath", "src/main/java")
     String sourceClassesPath = attributes.getOrDefault("sourceClassesPath", "build/classes/main")
     String testClassesPath = attributes.getOrDefault("testClassesPath", "build/classes/test")
+    String cachePath = attributes.getOrDefault("cachePath", "build/pmd.cache")
     String minimumPriority = attributes.getOrDefault("minimumPriority", "MEDIUM")
     String[] ruleSets = attributes.getOrDefault("ruleSets", [])
     boolean failOnViolations = attributes.getOrDefault("failOnViolations", true)
@@ -92,6 +93,7 @@ class LinterPlugin extends BaseGroovyPlugin {
 
     PMDConfiguration config = new PMDConfiguration()
     output.infoln("Using PMD version [%s]", PMDVersion.fullVersionName)
+    config.setAnalysisCacheLocation(project.directory.resolve(cachePath).toAbsolutePath().toString());
     config.addInputPath(project.directory.resolve(inputPath))
     def auxClassPath = [
         sourceClassesPath,

--- a/src/main/groovy/org/savantbuild/plugin/linter/LinterPlugin.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/linter/LinterPlugin.groovy
@@ -26,6 +26,7 @@ import org.savantbuild.plugin.groovy.BaseGroovyPlugin
 import org.savantbuild.runtime.RuntimeConfiguration
 
 import net.sourceforge.pmd.PMDConfiguration
+import net.sourceforge.pmd.PMDVersion
 import net.sourceforge.pmd.PmdAnalysis
 import net.sourceforge.pmd.lang.LanguageRegistry
 import net.sourceforge.pmd.lang.rule.RulePriority
@@ -81,6 +82,7 @@ class LinterPlugin extends BaseGroovyPlugin {
     Files.createDirectory(settings.reportDirectory)
 
     PMDConfiguration config = new PMDConfiguration()
+    output.infoln("Using PMD version [%s]", PMDVersion.fullVersionName)
     config.prependAuxClasspath(customRuleClassPath)
     config.addInputPath(project.directory.resolve(inputPath))
 


### PR DESCRIPTION
* Add support for supplying a Savant dependency group from the project containing custom rules to use
* Fix problem that prevented PMD from logging errors parsing rule XML (missing slf4j-simple dependency)
* PMD works better if you supply compiled code to it in the aux classpath, so add that in from the project (but don't require it) - see https://pmd.github.io/pmd/pmd_languages_java.html#providing-the-auxiliary-classpath for why
* Add support for PMD caching its results